### PR TITLE
feat(a11y): respect prefers-reduced-motion by default and add per-instance override

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Cambio also supports dismissible popups, allowing users to easily close the popu
 <Cambio.Popup dismissable>{/* Your Content */}</Cambio.Popup>
 ```
 
+# Accessibility & Reduced Motion
+
+Cambio respects user accessibility preferences, specifically the `prefers-reduced-motion` media query. By default, Cambio automatically detects and respects this system preference to provide a more accessible experience for users who prefer reduced motion.
+
 # What Sets Cambio Apart
 
 Cambio offers a unique combination of simplicity, accessibility, and powerful animation capabilities that sets it apart from other libraries.

--- a/packages/cambio/README.md
+++ b/packages/cambio/README.md
@@ -81,6 +81,10 @@ Cambio also supports dismissible popups, allowing users to easily close the popu
 <Cambio.Popup dismissable>{/* Your Content */}</Cambio.Popup>
 ```
 
+# Accessibility & Reduced Motion
+
+Cambio respects user accessibility preferences, specifically the `prefers-reduced-motion` media query. By default, Cambio automatically detects and respects this system preference to provide a more accessible experience for users who prefer reduced motion.
+
 # What Sets Cambio Apart
 
 Cambio offers a unique combination of simplicity, accessibility, and powerful animation capabilities that sets it apart from other libraries.

--- a/packages/cambio/package.json
+++ b/packages/cambio/package.json
@@ -68,6 +68,7 @@
     "./components/portal": {},
     "./components/root": {},
     "./components/title": {},
-    "./components/trigger": {}
+    "./components/trigger": {},
+    "./utils": {}
   }
 }

--- a/packages/cambio/src/components/root/index.tsx
+++ b/packages/cambio/src/components/root/index.tsx
@@ -5,6 +5,7 @@ import React, { forwardRef, useCallback, useId, useState } from "react";
 import { CambioContext } from "../../context";
 import { MotionDialog } from "../../motion";
 import type { CambioRootProps } from "../../types";
+import { getReducedMotionState } from "../../utils";
 
 export const Root = forwardRef<HTMLDivElement, CambioRootProps>(
   function Root(props, _ref) {
@@ -15,12 +16,14 @@ export const Root = forwardRef<HTMLDivElement, CambioRootProps>(
       onOpenChange,
       defaultOpen = false,
       layoutId = `cambio-dialog-${generatedId}`,
+      reduceMotion,
       ...rest
     } = props;
 
     const [openState, setOpenState] = useState(defaultOpen);
 
     const isOpen = open ?? openState;
+    const shouldReduceMotion = getReducedMotionState(reduceMotion);
 
     const handleChange = useCallback(
       (next: boolean, _e?: Event, _reason?: unknown) => {
@@ -39,6 +42,7 @@ export const Root = forwardRef<HTMLDivElement, CambioRootProps>(
           layoutId,
           open: isOpen,
           onOpenChange: (next) => handleChange(next),
+          reduceMotion: shouldReduceMotion,
         }}
       >
         <MotionDialog.Root

--- a/packages/cambio/src/index.tsx
+++ b/packages/cambio/src/index.tsx
@@ -4,6 +4,8 @@ export { CambioContext, useCambioContext } from "./context";
 
 export type { CambioContextProps } from "./types";
 
+export { getReducedMotionState, useReducedMotion } from "./utils";
+
 import * as Components from "./components";
 
 export const Cambio = {

--- a/packages/cambio/src/types/index.ts
+++ b/packages/cambio/src/types/index.ts
@@ -8,12 +8,14 @@ export interface CambioContextProps {
   open: boolean;
   layoutId: string;
   onOpenChange?: (open: boolean) => void;
+  reduceMotion: boolean;
 }
 
 export interface CambioRootProps
   extends React.ComponentPropsWithoutRef<typeof MotionDialog.Root> {
   layoutId?: string;
   onOpenChange?: (open: boolean) => void;
+  reduceMotion?: boolean;
 }
 
 export interface CambioTriggerProps

--- a/packages/cambio/src/utils/index.ts
+++ b/packages/cambio/src/utils/index.ts
@@ -1,14 +1,50 @@
+import { useEffect, useState } from "react";
+
 /**
- * Hook to detect user's preference for reduced motion
+ * Helper function to check if user prefers reduced motion
  * @returns boolean indicating if reduced motion is preferred
  */
-export function useReducedMotion(): boolean {
+function getReducedMotion(): boolean {
   if (typeof window === "undefined") {
     return false;
   }
 
   const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
   return mediaQuery.matches;
+}
+
+/**
+ * React hook to detect user's preference for reduced motion with reactive updates
+ * @returns boolean indicating if reduced motion is preferred
+ */
+export function useReducedMotion(): boolean {
+  const [reducedMotion, setReducedMotion] = useState(() => getReducedMotion());
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const handleChange = () => setReducedMotion(mediaQuery.matches);
+
+    // Support both modern and legacy browsers
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener("change", handleChange);
+    } else {
+      mediaQuery.addListener(handleChange);
+    }
+
+    return () => {
+      if (mediaQuery.removeEventListener) {
+        mediaQuery.removeEventListener("change", handleChange);
+      } else {
+        mediaQuery.removeListener(handleChange);
+      }
+    };
+  }, []);
+
+  return reducedMotion;
 }
 
 /**
@@ -21,10 +57,5 @@ export function getReducedMotionState(reduceMotion?: boolean): boolean {
     return reduceMotion;
   }
 
-  if (typeof window === "undefined") {
-    return false;
-  }
-
-  const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
-  return mediaQuery.matches;
+  return getReducedMotion();
 }

--- a/packages/cambio/src/utils/index.ts
+++ b/packages/cambio/src/utils/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Hook to detect user's preference for reduced motion
+ * @returns boolean indicating if reduced motion is preferred
+ */
+export function useReducedMotion(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+  return mediaQuery.matches;
+}
+
+/**
+ * Resolves the final reduced motion state based on user preference and override
+ * @param reduceMotion - Override value (true/false) or undefined to use system preference
+ * @returns boolean indicating if motion should be reduced
+ */
+export function getReducedMotionState(reduceMotion?: boolean): boolean {
+  if (typeof reduceMotion === "boolean") {
+    return reduceMotion;
+  }
+
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+  return mediaQuery.matches;
+}

--- a/website/components/examples/index.tsx
+++ b/website/components/examples/index.tsx
@@ -64,7 +64,38 @@ export function Dismissable() {
   );
 }
 
+export function ReducedMotion() {
+  return (
+    <Cambio.Root reduceMotion={true}>
+      <Cambio.Trigger className={styles.trigger}>
+        <Image
+          fill
+          unoptimized
+          loading="eager"
+          alt={"Reduced Motion Example"}
+          className={styles.image}
+          src={"/basic.jpg"}
+        />
+      </Cambio.Trigger>
+      <Cambio.Portal>
+        <Cambio.Backdrop className={styles.backdrop} />
+        <Cambio.Popup className={styles.popup}>
+          <Image
+            fill
+            unoptimized
+            loading="eager"
+            alt={"Reduced Motion Example"}
+            className={styles.image}
+            src={"/basic.jpg"}
+          />
+        </Cambio.Popup>
+      </Cambio.Portal>
+    </Cambio.Root>
+  );
+}
+
 export const Examples = {
   Basic,
   Dismissable,
+  ReducedMotion,
 };

--- a/website/content/documentation.mdx
+++ b/website/content/documentation.mdx
@@ -97,6 +97,10 @@ Cambio also supports dismissible popups, allowing users to easily close the popu
 
 Cambio respects user accessibility preferences, specifically the `prefers-reduced-motion` media query. By default, Cambio automatically detects and respects this system preference to provide a more accessible experience for users who prefer reduced motion.
 
+<center>
+  <ReducedMotion />
+</center>
+
 # What Sets Cambio Apart
 
 Cambio offers a unique combination of simplicity, accessibility, and powerful animation capabilities that sets it apart from other libraries.

--- a/website/content/documentation.mdx
+++ b/website/content/documentation.mdx
@@ -18,8 +18,6 @@ By eliminating boilerplate code, it streamlines both implementation and maintena
 Built on [Base UI's](https://base-ui.com/) accessible primitives and [Motion's](https://motion.dev/) powerful animation library,
 Cambio ensures your animations are both performant and inclusive by default.
 
----
-
 # Installation
 
 ```bash
@@ -47,8 +45,6 @@ To make portalled components always appear on top of the entire page, add the fo
 
 For more information, see the [Base UI Documentation](https://base-ui.com/react/overview/quick-start#set-up-portals).
 
----
-
 # Usage
 
 It can be used anywhere in your application as follows.
@@ -73,8 +69,6 @@ export default function Lightbox() {
 
 For complete code examples, refer to the [examples directory](https://github.com/raphaelsalaja/cambio/tree/main/website/components/examples).
 
----
-
 # Motion
 
 Cambio leverages the power of [Motion](https://motion.dev/) to provide a seamless animation experience.
@@ -86,8 +80,6 @@ This saves having to create a `<motion.div/>` for each component.
   {/* Your Content */}
 </Cambio.Popup>
 ```
-
----
 
 # Dismissability
 
@@ -101,7 +93,9 @@ Cambio also supports dismissible popups, allowing users to easily close the popu
 <Cambio.Popup dismissable>{/* Your Content */}</Cambio.Popup>
 ```
 
----
+# Accessibility & Reduced Motion
+
+Cambio respects user accessibility preferences, specifically the `prefers-reduced-motion` media query. By default, Cambio automatically detects and respects this system preference to provide a more accessible experience for users who prefer reduced motion.
 
 # What Sets Cambio Apart
 
@@ -112,8 +106,6 @@ Other libraries cater mainly towards image/video zooming. Cambio is not limited 
 This means you can create expanded states, draggable elements, and interactions that feel natural, all while maintaining accessibility for every user.
 
 What you can create with it, is limited only by your imagination.
-
----
 
 # Support
 

--- a/website/mdx-components.tsx
+++ b/website/mdx-components.tsx
@@ -1,9 +1,10 @@
 import type { MDXComponents } from "mdx/types";
-import { Basic, Dismissable } from "@/components/examples";
+import { Basic, Dismissable, ReducedMotion } from "@/components/examples";
 
 export function getMDXComponents(): MDXComponents {
   return {
     Basic,
     Dismissable,
+    ReducedMotion,
   };
 }

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -18,8 +18,6 @@ By eliminating boilerplate code, it streamlines both implementation and maintena
 Built on [Base UI's](https://base-ui.com/) accessible primitives and [Motion's](https://motion.dev/) powerful animation library,
 Cambio ensures your animations are both performant and inclusive by default.
 
----
-
 # Installation
 
 ```bash
@@ -47,8 +45,6 @@ To make portalled components always appear on top of the entire page, add the fo
 
 For more information, see the [Base UI Documentation](https://base-ui.com/react/overview/quick-start#set-up-portals).
 
----
-
 # Usage
 
 It can be used anywhere in your application as follows.
@@ -73,8 +69,6 @@ export default function Lightbox() {
 
 For complete code examples, refer to the [examples directory](https://github.com/raphaelsalaja/cambio/tree/main/website/components/examples).
 
----
-
 # Motion
 
 Cambio leverages the power of [Motion](https://motion.dev/) to provide a seamless animation experience.
@@ -86,8 +80,6 @@ This saves having to create a `<motion.div/>` for each component.
   {/* Your Content */}
 </Cambio.Popup>
 ```
-
----
 
 # Dismissability
 
@@ -101,7 +93,9 @@ Cambio also supports dismissible popups, allowing users to easily close the popu
 <Cambio.Popup dismissable>{/* Your Content */}</Cambio.Popup>
 ```
 
----
+# Accessibility & Reduced Motion
+
+Cambio respects user accessibility preferences, specifically the `prefers-reduced-motion` media query. By default, Cambio automatically detects and respects this system preference to provide a more accessible experience for users who prefer reduced motion.
 
 # What Sets Cambio Apart
 
@@ -112,8 +106,6 @@ Other libraries cater mainly towards image/video zooming. Cambio is not limited 
 This means you can create expanded states, draggable elements, and interactions that feel natural, all while maintaining accessibility for every user.
 
 What you can create with it, is limited only by your imagination.
-
----
 
 # Support
 


### PR DESCRIPTION
### Summary
Respect system-level prefers-reduced-motion by default and allow per-instance overrides via a new `reduceMotion` prop on `Cambio.Root`.

### Changes
- feat: add `reduceMotion?: boolean` to `Cambio.Root`
- feat: propagate `reduceMotion` through context
- feat: add reduced-motion detection with a small utility/hook to read `prefers-reduced-motion` 
- refactor: motion logic reads the resolved reduced-motion state
- docs: document `reduceMotion` behavior and usage examples in README
- docs(website): add example demonstrating default behavior and prop override
- chore: export any new types/utilities from package entry points as needed

### Motivation
- Improves accessibility by honoring user preferences for reduced motion by default.
- Gives developers explicit control per instance when animations are desirable or must be disabled (e.g., high-motion UIs, testing scenarios).