### PR TITLE
feat(backdrop): improve animation behavior and cleanup code

### DIFF
--- a/packages/cambio/src/components/backdrop/index.tsx
+++ b/packages/cambio/src/components/backdrop/index.tsx
@@ -10,7 +10,6 @@ import { getComponentMotionPreset, getMotionConfig } from "../../utils";
 export const Backdrop = React.forwardRef<HTMLDivElement, CambioBackdropProps>(
   function Backdrop({ motion: componentMotion, ...props }, ref) {
     const {
-      layoutId,
       open,
       motion: globalMotion,
       motionVariants,
@@ -35,16 +34,19 @@ export const Backdrop = React.forwardRef<HTMLDivElement, CambioBackdropProps>(
     } = props;
 
     return (
-      <AnimatePresence>
+      <AnimatePresence initial={false}>
         {open && (
           <MotionDialog.Backdrop
             {...props}
             ref={ref}
-            key={`cambio-backdrop-${layoutId}`}
             transition={transition}
             initial={initial}
             animate={animate}
             exit={exit}
+            style={{
+              ...props.style,
+              display: "block",
+            }}
           />
         )}
       </AnimatePresence>

--- a/website/components/examples/basic/index.tsx
+++ b/website/components/examples/basic/index.tsx
@@ -7,7 +7,7 @@ import styles from "../styles.module.css";
 
 export function Basic() {
   return (
-    <Cambio.Root>
+    <Cambio.Root dismissible motion="bouncy">
       <Cambio.Trigger className={styles.trigger}>
         <Image variant="basic" />
       </Cambio.Trigger>


### PR DESCRIPTION
### Summary
Improved the backdrop component's animation behavior by removing unnecessary layoutId dependency and adding better default styling.

### Motivation
The backdrop component was using layoutId unnecessarily, which could cause animation conflicts and wasn't needed for backdrop-specific animations. Additionally, the AnimatePresence needed better configuration for smoother enter/exit animations.

### Changes
- Remove layoutId destructuring and usage from backdrop component
- Set AnimatePresence initial={false} for better animation performance 
- Add default display: "block" style to ensure proper backdrop rendering
- Update basic example to include dismissible and motion props for better demonstration